### PR TITLE
React Native 0.26

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
-import React, {
-  Component,
+import React, { Component } from 'react'
+import {
   ListView,
   PropTypes,
   StyleSheet,
@@ -23,7 +23,7 @@ class AutoComplete extends Component {
      * Assign an array of data objects which should be
      * rendered in respect to the entered text.
      */
-    data: PropTypes.array,
+    data: React.PropTypes.array,
     /*
      * These styles will be applied to the container which surrounds
      * the textInput component.
@@ -38,7 +38,7 @@ class AutoComplete extends Component {
      * which will be displayed in the result view below the
      * text input.
      */
-    renderItem: PropTypes.func
+    renderItem: React.PropTypes.func
   };
 
   static defaultProps = {


### PR DESCRIPTION
Why:

* Latest React Native no longer users `React` and `Component` from
  `react-native` package.

This change addresses the need by:

* Pull `React` and `Component` from `react` package.
* PropTypes had to be prefixed with `React`. (not sure why but that was the error I was given)