### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ class AutoComplete extends Component {
     const ds = new ListView.DataSource({ rowHasChanged: (r1, r2) => r1 !== r2 });
     this.state = {
       dataSource: ds.cloneWithRows(props.data),
-      showResults: false
+      showResults: props.data && props.data.length > 0
     };
   }
 


### PR DESCRIPTION
lets say I have component A that uses RNAI. Currently, the code assumes the `data` are shown only after user does some interaction in A (enters text) and the `data` is changed, which will cause the new `data` prop to be passed to componentWillReceiveProps, and render the listView. In my use case, I already have a pre-populated list and it makes sense to display it to the user right away - so I'm testing the `data` array size (same as on line 62) right in the constructor.