### PR TITLE
fix: use correct PropTypes for style props

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ class Autocomplete extends Component {
      * These styles will be applied to the container which
      * surrounds the autocomplete component.
      */
-    containerStyle: PropTypes.object,
+    containerStyle: View.PropTypes.style,
     /**
      * Assign an array of data objects which should be
      * rendered in respect to the entered text.
@@ -25,16 +25,16 @@ class Autocomplete extends Component {
      * These styles will be applied to the container which surrounds
      * the textInput component.
      */
-    inputContainerStyle: PropTypes.object,
+    inputContainerStyle: View.PropTypes.style,
     /*
      * These styles will be applied to the container which surrounds
      * the result list.
      */
-    listContainerStyle: PropTypes.object,
+    listContainerStyle: View.PropTypes.style,
     /**
      * These style will be applied to the result list.
      */
-    listStyle: PropTypes.object,
+    listStyle: ListView.PropTypes.style,
     /**
      * `onShowResults` will be called when list is going to
      * show/hide results.


### PR DESCRIPTION
The `StyleSheet.create` function returns its styles as a number instead of an object.