### PR TITLE
Allows an option to hide results

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,7 +127,8 @@ class Autocomplete extends Component {
       containerStyle,
       inputContainerStyle,
       listContainerStyle,
-      onShowResults
+      onShowResults,
+      hideResults
     } = this.props;
     const showResults = dataSource.getRowCount() > 0;
 
@@ -139,9 +140,12 @@ class Autocomplete extends Component {
         <View style={[styles.inputContainer, inputContainerStyle]}>
           {this.renderTextInput()}
         </View>
-        <View style={listContainerStyle}>
-          {showResults && this.renderResultList()}
-        </View>
+        {
+          !hideResults &&
+          <View style={listContainerStyle}>
+            {showResults && this.renderResultList()}
+          </View>
+        }
       </View>
     );
   }


### PR DESCRIPTION
Current implementation hides the results only if the selected text is unique
An option to 'hideResults' can be used to set this property using onPress events on a Touchable component