### PR TITLE
Support passing keyboardShouldPersistTaps prop for compatibility with RN <= 0.39.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ const styles = StyleSheet.create({
 | renderTextInput | function | render custom TextInput. All props passed to this function. |
 
 ## Known issues
-* By default the autocomplete will not behave as expected inside a `<ScrollView />`. Set the scroll view's prop `keyboardShouldPersistTaps={true}` to fix this ([#5](https://github.com/l-urence/react-native-autocomplete-input/issues/5)).
+* By default the autocomplete will not behave as expected inside a `<ScrollView />`. Set the scroll view's prop to fix this: `keyboardShouldPersistTaps={true}` for RN <= 0.39, or `keyboardShouldPersistTaps='always'` for RN >= 0.40. ([#5](https://github.com/l-urence/react-native-autocomplete-input/issues/5)).
 * If you want to test with Jest add ```jest.mock('react-native-autocomplete-input', () => 'Autocomplete');``` to your test.
 
 ## Contribute

--- a/index.js
+++ b/index.js
@@ -67,7 +67,8 @@ class Autocomplete extends Component {
     defaultValue: '',
     renderItem: rowData => <Text>{rowData}</Text>,
     renderSeparator: null,
-    renderTextInput: props => <TextInput {...props} />
+    renderTextInput: props => <TextInput {...props} />,
+    keyboardShouldPersistTaps: 'always',
   };
 
   constructor(props) {
@@ -100,12 +101,12 @@ class Autocomplete extends Component {
 
   renderResultList() {
     const { dataSource } = this.state;
-    const { listStyle, renderItem, renderSeparator } = this.props;
+    const { listStyle, renderItem, renderSeparator, keyboardShouldPersistTaps } = this.props;
 
     return (
       <ListView
         dataSource={dataSource}
-        keyboardShouldPersistTaps="always"
+        keyboardShouldPersistTaps={keyboardShouldPersistTaps}
         renderRow={renderItem}
         renderSeparator={renderSeparator}
         style={[styles.list, listStyle]}


### PR DESCRIPTION
`keyboardShouldPersistTaps` has a default value of `always`.  If the parent passes in the prop, it will override the default.  This allows RN <= 0.39 to pass in a `true` value to continue operating properly.

See #41