### PR TITLE
added onStartShouldSetResponderCapture

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,11 @@ class Autocomplete extends Component {
     /**
      * renders custom TextInput. All props passed to this function.
      */
-    renderTextInput: PropTypes.func
+    renderTextInput: PropTypes.func,
+    /**
+     * method for intercepting swipe on ListView. Used for ScrollView support on Android
+     */
+    onStartShouldSetResponderCapture: PropTypes.func
   };
 
   static defaultProps = {
@@ -104,6 +108,7 @@ class Autocomplete extends Component {
 
     return (
       <ListView
+        ref={"resultList"}
         dataSource={dataSource}
         keyboardShouldPersistTaps="always"
         renderRow={renderItem}
@@ -132,7 +137,8 @@ class Autocomplete extends Component {
       hideResults,
       inputContainerStyle,
       listContainerStyle,
-      onShowResults
+      onShowResults,
+      onStartShouldSetResponderCapture: intercept
     } = this.props;
     const showResults = dataSource.getRowCount() > 0;
 
@@ -145,7 +151,11 @@ class Autocomplete extends Component {
           {this.renderTextInput()}
         </View>
         {!hideResults && (
-          <View style={listContainerStyle}>
+          <View
+            onStartShouldSetResponderCapture={() => {
+              intercept ? intercept(this.refs.resultList) : console.log('onStartShouldSetResponderCapture is not defined');
+            }}
+            style={listContainerStyle}>
             {showResults && this.renderResultList()}
           </View>
         )}

--- a/index.js
+++ b/index.js
@@ -79,6 +79,7 @@ class Autocomplete extends Component {
 
     const ds = new ListView.DataSource({ rowHasChanged: (r1, r2) => r1 !== r2 });
     this.state = { dataSource: ds.cloneWithRows(props.data) };
+    this.resultList = null;
   }
 
   componentWillReceiveProps({ data }) {
@@ -108,7 +109,7 @@ class Autocomplete extends Component {
 
     return (
       <ListView
-        ref={"resultList"}
+        ref={(resultList) => { this.resultList = resultList; }}
         dataSource={dataSource}
         keyboardShouldPersistTaps="always"
         renderRow={renderItem}
@@ -153,7 +154,9 @@ class Autocomplete extends Component {
         {!hideResults && (
           <View
             onStartShouldSetResponderCapture={() => {
-              intercept ? intercept(this.refs.resultList) : console.log('onStartShouldSetResponderCapture is not defined');
+              if (intercept) {
+                intercept(this.resultList);
+              }
             }}
             style={listContainerStyle}>
             {showResults && this.renderResultList()}

--- a/index.js
+++ b/index.js
@@ -159,7 +159,7 @@ class Autocomplete extends Component {
               }
             }}
             style={listContainerStyle}
-           >
+          >
             {showResults && this.renderResultList()}
           </View>
         )}

--- a/index.js
+++ b/index.js
@@ -158,7 +158,8 @@ class Autocomplete extends Component {
                 intercept(this.resultList);
               }
             }}
-            style={listContainerStyle}>
+            style={listContainerStyle}
+           >
             {showResults && this.renderResultList()}
           </View>
         )}


### PR DESCRIPTION
when using this module on Android in ScrollView - results are not scrollable.
added onStartShouldSetResponderCapture prop on View, wrapping ListView, containing results.
this will help to understand - when user taps on ListView and when - on ScrollView.
prop is optional.