### PR TITLE
fix listview_prop_types

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ class Autocomplete extends Component {
     /*
      * Set `keyboardShouldPersistTaps` to true if RN version is <= 0.39.
      */
-    keyboardShouldPersistTaps: View.propTypes.keyboardShouldPersistTaps,
+    keyboardShouldPersistTaps: ListView.propTypes.keyboardShouldPersistTaps,
     /*
      * These styles will be applied to the container which surrounds
      * the result list.


### PR DESCRIPTION
Do this after merge: https://github.com/l-urence/react-native-autocomplete-input/pull/46

This fix should prevail