### PR TITLE
fix invalid keyboardShouldPersistTaps prop type

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,10 @@ class Autocomplete extends Component {
     /*
      * Set `keyboardShouldPersistTaps` to true if RN version is <= 0.39.
      */
-    keyboardShouldPersistTaps: View.propTypes.keyboardShouldPersistTaps,
+    keyboardShouldPersistTaps: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.boolean
+    ]),
     /*
      * These styles will be applied to the container which surrounds
      * the result list.


### PR DESCRIPTION
The PR fixes the warning which shows up in RN 0.45:

`Failed prop type: Autocomplete: prop type 'keyboardShouldPersistTaps' is invalid; it must be a function, usually from React.PropTypes.`

However, it's supposed to be ether a string or a boolean.