### PR TITLE
Migrate to prop-types package.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,16 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
 import {
   ListView,
   Platform,
   StyleSheet,
   Text,
   TextInput,
-  View
+  View,
+  ViewPropTypes
 } from 'react-native';
+import PropTypes from 'prop-types';
+
+let rnVersion = Number.parseFloat(require('react-native/package.json').version);
 
 class Autocomplete extends Component {
   static propTypes = {
@@ -15,7 +19,7 @@ class Autocomplete extends Component {
      * These styles will be applied to the container which
      * surrounds the autocomplete component.
      */
-    containerStyle: View.propTypes.style,
+    containerStyle: rnVersion >= 0.44 ? ViewPropTypes.style : View.propTypes.style,
     /**
      * Assign an array of data objects which should be
      * rendered in respect to the entered text.
@@ -29,16 +33,19 @@ class Autocomplete extends Component {
      * These styles will be applied to the container which surrounds
      * the textInput component.
      */
-    inputContainerStyle: View.propTypes.style,
+    inputContainerStyle: rnVersion >= 0.44 ? ViewPropTypes.style : View.propTypes.style,
     /*
      * Set `keyboardShouldPersistTaps` to true if RN version is <= 0.39.
      */
-    keyboardShouldPersistTaps: ListView.propTypes.keyboardShouldPersistTaps,
+    keyboardShouldPersistTaps: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.bool
+    ]),
     /*
      * These styles will be applied to the container which surrounds
      * the result list.
      */
-    listContainerStyle: View.propTypes.style,
+    listContainerStyle: rnVersion >= 0.44 ? ViewPropTypes.style : View.propTypes.style,
     /**
      * These style will be applied to the result list.
      */

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ import {
   Text,
   TextInput,
   View,
-  ViewPropTypes as RNViewPropTypes,
+  ViewPropTypes as RNViewPropTypes
 } from 'react-native';
 import PropTypes from 'prop-types';
 

--- a/index.js
+++ b/index.js
@@ -6,11 +6,11 @@ import {
   Text,
   TextInput,
   View,
-  ViewPropTypes
+  ViewPropTypes as RNViewPropTypes,
 } from 'react-native';
 import PropTypes from 'prop-types';
 
-let rnVersion = Number.parseFloat(require('react-native/package.json').version);
+const ViewPropTypes = RNViewPropTypes || View.propTypes;
 
 class Autocomplete extends Component {
   static propTypes = {
@@ -19,7 +19,7 @@ class Autocomplete extends Component {
      * These styles will be applied to the container which
      * surrounds the autocomplete component.
      */
-    containerStyle: rnVersion >= 0.44 ? ViewPropTypes.style : View.propTypes.style,
+    containerStyle: ViewPropTypes.style,
     /**
      * Assign an array of data objects which should be
      * rendered in respect to the entered text.
@@ -33,7 +33,7 @@ class Autocomplete extends Component {
      * These styles will be applied to the container which surrounds
      * the textInput component.
      */
-    inputContainerStyle: rnVersion >= 0.44 ? ViewPropTypes.style : View.propTypes.style,
+    inputContainerStyle: ViewPropTypes.style,
     /*
      * Set `keyboardShouldPersistTaps` to true if RN version is <= 0.39.
      */
@@ -45,7 +45,7 @@ class Autocomplete extends Component {
      * These styles will be applied to the container which surrounds
      * the result list.
      */
-    listContainerStyle: rnVersion >= 0.44 ? ViewPropTypes.style : View.propTypes.style,
+    listContainerStyle: ViewPropTypes.style,
     /**
      * These style will be applied to the result list.
      */

--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
     "url": "https://github.com/l-urence/react-native-autocomplete-input/issues"
   },
   "homepage": "https://github.com/l-urence/react-native-autocomplete-input#readme",
+  "dependencies": {
+    "prop-types": "^15.5.10"
+  },
   "devDependencies": {
     "babel-eslint": "^7.1.1",
     "babel-preset-react-native": "^1.9.1",


### PR DESCRIPTION
Use prop-types package (React.PropTypes has been deprecated).
Conditionally use ViewPropTypes (View.propTypes has been deprecated).
See  #54